### PR TITLE
alteração do formato da data enviada para a api da Rede

### DIFF
--- a/src/Rede/QrCode.php
+++ b/src/Rede/QrCode.php
@@ -40,7 +40,7 @@ class QrCode implements RedeSerializable
     public function jsonSerialize(): array
     {
         return [
-            'dateTimeExpiration' => $this->getDateTimeExpiration()?->format('c') ?: null,
+            'dateTimeExpiration' => $this->getDateTimeExpiration()?->format('Y-m-d\TH:i:s') ?: null,
         ];
     }
 


### PR DESCRIPTION
Essa PR corrige o erro do formato da data enviado para a Api da Rede.

Utilizando o format('c') o retorno estava sendo:
**Expiration Date invalid format. #3078**

Alterado o formato para 'Y-m-d\TH:i:s'